### PR TITLE
feat(darktower): add FreshRSS container behind reverse proxy

### DIFF
--- a/machines/darktower/default.nix
+++ b/machines/darktower/default.nix
@@ -10,6 +10,7 @@
     ../../modules/nixos/server
 
     ./services/fileserver.nix
+    ./services/freshrss.nix
     ./services/mysql.nix
     ./services/postgresql.nix
     ./services/reverseproxy.nix

--- a/machines/darktower/services/freshrss.nix
+++ b/machines/darktower/services/freshrss.nix
@@ -1,0 +1,63 @@
+{
+  containers = {
+    reverseproxy.config.services.nginx.virtualHosts."feeds.robot-disco.net" = {
+      locations."/" = {
+        proxyPass = "http://192.168.50.3:80";
+      };
+      forceSSL = true;
+      enableACME = true;
+    };
+
+    postgresql.config.services.postgresql = {
+      authentication = ''
+        host freshrss freshrss 192.168.50.3/32 scram-sha-256
+      '';
+      ensureDatabases = [ "freshrss" ];
+      ensureUsers = [
+        {
+          name = "freshrss";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    feeds = {
+      autoStart = true;
+      privateNetwork = true;
+      hostBridge = "br50";
+      localAddress = "192.168.50.3/24";
+      bindMounts = {
+        "/var/lib/freshrss" = {
+          hostPath = "/srv/storagepool/data/freshrss";
+          isReadOnly = false;
+        };
+      };
+
+      config = {
+        system.stateVersion = "26.05";
+
+        networking = {
+          defaultGateway = "192.168.50.1";
+          firewall.allowedTCPPorts = [ 80 ];
+          nameservers = [ "192.168.50.1" ];
+        };
+
+        services.freshrss = {
+          api.enable = true;
+          enable = true;
+
+          baseUrl = "https://feeds.robot-disco.net";
+          defaultUser = "gaelan";
+          passwordFile = "/var/lib/freshrss/admin_password";
+          virtualHost = "feeds.robot-disco.net";
+
+          database = {
+            type = "pgsql";
+            host = "192.168.10.3";
+            passFile = "/var/lib/freshrss/db_password";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a new `feeds` container (192.168.50.3, br50) running `services.freshrss` against the existing `postgresql` container, exposed at `feeds.robot-disco.net` via the `reverseproxy` container.
- Follows the existing vaultwarden/webdav convention: each service file self-merges into `containers.reverseproxy` and `containers.postgresql` rather than editing those files directly.
- Fixes the original draft's issues: unbalanced braces (syntax error), wrong option path (`freshrss.*` → `services.freshrss.*`), wrong DB option name (`passwordFile` → `database.passFile`), typo'd proxy IP (192.16**7**.50.3 → 192.16**8**.50.3), missing scheme/port on `proxyPass`, empty container firewall (blocked all inbound), and missing persistent bind mount for `/var/lib/freshrss`.
- Admin password (`passwordFile`) and DB password (`database.passFile`) point at files under the bind-mounted data dir (`/srv/storagepool/data/freshrss` on the host) — these are **not** managed by nix and need to be placed there by hand, matching how vaultwarden's secrets file works today.

## Test plan
- [x] `nix-instantiate --parse` on the new file
- [x] `nix eval .#nixosConfigurations.darktower.config.system.build.toplevel.drvPath` succeeds
- [x] `just fmt` — no changes needed
- [x] `just lint` — no new warnings (pre-existing, unrelated warning in `gaelan-kata.nix`)
- [ ] Deploy to darktower and confirm FreshRSS comes up once secrets are placed (not done here — requires the actual host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)